### PR TITLE
Fix #38 : cast duration to an integer

### DIFF
--- a/acoustid.py
+++ b/acoustid.py
@@ -366,6 +366,9 @@ def submit(apikey, userkey, data):
     for i, d in enumerate(data):
         if "duration" not in d or "fingerprint" not in d:
             raise FingerprintSubmissionError("missing required parameters")
+        if not isinstance(d["duration"], int):
+            # Cast duration to an integer
+            d["duration"] = int(float(d["duration"]))
         for k, v in d.items():
             args["%s.%s" % (k, i)] = v
 


### PR DESCRIPTION
we could also use math.floor or round depending on what's the best for acoustid ... Tell me if one of them is better.

The `float` call is made to handle the case when duration is a string or else.